### PR TITLE
fix: declare CMD after 'shift' function

### DIFF
--- a/cuda_python/run_local.sh
+++ b/cuda_python/run_local.sh
@@ -11,7 +11,6 @@ GROUP_ID=`id -g`
 GROUP_NAME=`id -gn`
 USER_NAME=$USER
 
-CMD=$@
 
 DESCRIPTION=$(cat <<< "CUDA + Python Docker
 同階層にpoetry, requirements.txtを置くと自動でパッケージがインストールされます
@@ -64,6 +63,7 @@ for OPT in "$@"; do
     esac
 done
 
+CMD=$@
 IMAGE_NAME="${USER_NAME}/cuda${CUDA_VERSION//./}-python${PYTHON//./}-server:latest"
 CONTAINER_NAME="${USER_NAME}-cuda${CUDA_VERSION//./}-python${PYTHON//./}-server${CONTAINER_NAME_PREFIX}"
 


### PR DESCRIPTION
## Overview
`./run_local.sh` の引数に対するバグ修正。

## Detail
imageのbuild後、run_local.shの実行にて下記のエラー。

```
% ./run_local.sh -c 11.3.1 -u 20.04 -p 3.8.16
error: exec: "-c 11.3.1 -u 20.04 -p 3.8.16": executable file not found in $PATH
```

`CMD=$@` で全ての引数を受け入れてる部分は、その後のオプション処理によって変更されることがない。
変数の設定をスクリプトのオプション処理の後に移動させると正しく動く。